### PR TITLE
Update to fix HTTP endpoints

### DIFF
--- a/beneve-framework/pom.xml
+++ b/beneve-framework/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.beneve</groupId>
@@ -9,7 +9,7 @@
 
 	<name>Beneve Framework</name>
 
-	<url>http://www.beneve.cn</url>
+	<url>https://www.beneve.cn</url>
 	<inceptionYear>2016-07-09</inceptionYear>
 	<description>
 	   This is a build using Maven Based on the boot spring framework Project for developing Web Java
@@ -58,7 +58,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/libs-snapshot-local</url>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -66,7 +66,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/libs-milestone-local</url>
+			<url>https://repo.spring.io/libs-milestone-local</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -74,7 +74,7 @@
 		<repository>
 			<id>spring-releases</id>
 			<name>Spring Releases</name>
-			<url>http://repo.spring.io/libs-release-local</url>
+			<url>https://repo.spring.io/libs-release-local</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -84,7 +84,7 @@
 		<pluginRepository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/libs-snapshot-local</url>
+			<url>https://repo.spring.io/libs-snapshot-local</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -92,7 +92,7 @@
 		<pluginRepository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/libs-milestone-local</url>
+			<url>https://repo.spring.io/libs-milestone-local</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -110,16 +110,16 @@
 				<role>developer</role>
 			</roles>
 			<organization>Beneve</organization>
-			<organizationUrl>Http://www.beneve.cn</organizationUrl>
+			<organizationUrl>https://www.beneve.cn</organizationUrl>
 		</developer>
 
 		<developer>
 			<id>guobinwu</id>
 			<name>Guobin Wu</name>
 			<email>guobin.wu@hotmail.com</email>
-			<url>http://guobinwu.github.io/</url>
+			<url>https://guobinwu.github.io/</url>
 			<organization>Beneve</organization>
-			<organizationUrl>http://www.beneve.cn</organizationUrl>
+			<organizationUrl>https://www.beneve.cn</organizationUrl>
 			<roles>
 				<role>ProjectManager</role>
 				<role>Architect</role>


### PR DESCRIPTION
Some of the endpoints are still using HTTP that is insecure ... replaced with secure HTTP (HTTP with SSL/TLS) that exists

Details:

I found instances where the HTTP protocol is used instead of HTTPS (HTTP with TLS). According to the Common Weakness Enumeration organization this is a security weakness (https://cwe.mitre.org/data/definitions/319.html).